### PR TITLE
ci: pre-built multi-platform release binaries (closes #37)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 # ensure that the workflow is only triggered once per ref, subsequent runs on the ref will cancel
 # and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -18,6 +15,8 @@ jobs:
   release:
     name: release ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -50,4 +49,5 @@ jobs:
           archive: sigye-$target
           checksum: sha256
           locked: true
+          dry-run: ${{ github.event_name != 'release' }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# ensure that the workflow is only triggered once per ref, subsequent runs on the ref will cancel
+# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: release ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build and upload binary
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: sigye
+          target: ${{ matrix.target }}
+          manifest-path: crates/sigye/Cargo.toml
+          archive: sigye-$target
+          checksum: sha256
+          locked: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ A feature-rich terminal clock with ASCII art fonts, animated backgrounds, and pr
 
 ## Installation
 
+### Pre-built binaries
+
+Download pre-built binaries from the [GitHub Releases](https://github.com/am2rican5/sigye/releases) page.
+
+Supported platforms: Linux x86_64 gnu/musl, Linux aarch64, macOS Intel + Apple Silicon, Windows x86_64.
+
 ### From crates.io
 
 ```bash

--- a/docs/plans/release-binaries.md
+++ b/docs/plans/release-binaries.md
@@ -1,0 +1,69 @@
+# Plan: Pre-built release binaries (issue #37)
+
+## Goal
+Provide pre-built `sigye` binaries for multiple platforms, attached to GitHub
+Releases, so users can install without the Rust toolchain.
+
+## Key facts (verified against Cargo.lock)
+- Binary name: `sigye`, workspace member at `crates/sigye` (manifest path
+  `crates/sigye/Cargo.toml`). Workspace root `Cargo.toml`.
+- **No C system-library build deps on Linux:**
+  - `arboard` -> pure-Rust `x11rb` (no libxcb dev libs)
+  - `notify-rust` -> pure-Rust `zbus` (no libdbus dev libs)
+  - `ureq` -> `rustls` (no OpenSSL)
+  => Cross-compilation and musl static builds are clean (no `apt-get` needed).
+- Release profile already optimized (lto, strip, opt-level "s").
+- Existing `publish.yml` triggers on `release: published` (crates.io publish).
+
+## Deliverable
+New workflow: `.github/workflows/release.yml`
+
+### Triggers
+- `release: { types: [published] }`  (aligns with publish.yml; uploads assets to
+  the just-published release; `github.ref` = the tag)
+- `workflow_dispatch` (manual; for testing builds)
+
+### Permissions
+- `contents: write` (needed to upload release assets)
+
+### Build matrix (target -> runner)
+- `x86_64-unknown-linux-gnu`   -> ubuntu-latest
+- `x86_64-unknown-linux-musl`  -> ubuntu-latest  (static)
+- `aarch64-unknown-linux-gnu`  -> ubuntu-latest  (cross)
+- `x86_64-apple-darwin`        -> macos-13       (intel)
+- `aarch64-apple-darwin`       -> macos-latest   (apple silicon)
+- `x86_64-pc-windows-msvc`     -> windows-latest
+
+`fail-fast: false` so one target failing doesn't kill the others.
+
+### Build/upload approach
+Use `taiki-e/upload-rust-binary-action@v1` per matrix entry:
+- `bin: sigye`
+- `target: ${{ matrix.target }}`
+- `manifest-path: crates/sigye/Cargo.toml`  (workspace member)
+- `archive: sigye-$target`  (tar.gz on unix, zip on windows automatically)
+- `checksum: sha256`
+- `locked: true`  (build with --locked since Cargo.lock is committed)
+- `token: ${{ secrets.GITHUB_TOKEN }}`
+- For non-native Linux targets (`aarch64-unknown-linux-gnu`,
+  `x86_64-unknown-linux-musl`) the action uses `cross`/cargo automatically;
+  since there are no C deps, no extra system packages are required.
+
+The action only uploads to a release when run in a tag/release context. On
+`workflow_dispatch` (no tag) it will still build (validating the matrix) but
+won't have a release to upload to — that's acceptable for a manual test run.
+Pin the action to its `@v1` major tag.
+
+### README update
+Add a "Pre-built binaries" subsection under Installation pointing users to the
+GitHub Releases page, noting the available platforms.
+
+## Out of scope
+- Auto-creating releases from tag pushes (maintainer creates releases manually,
+  which is what publish.yml already keys off of).
+- Package-manager distribution (homebrew, AUR, etc.).
+
+## Verification
+- `actionlint` (or yaml parse) on the workflow file.
+- Confirm matrix targets are valid rustc target triples.
+- Confirm trigger does not conflict/duplicate publish.yml's job.


### PR DESCRIPTION
## Summary

Resolves #37 — provides pre-built `sigye` binaries so users can install without the Rust toolchain.

Adds `.github/workflows/release.yml` which builds the `sigye` binary across a 6-target matrix and attaches `.tar.gz`/`.zip` archives plus `sha256` checksums to GitHub Releases via [`taiki-e/upload-rust-binary-action`](https://github.com/taiki-e/upload-rust-binary-action).

### Platforms
| Target | Runner | Build |
|---|---|---|
| `x86_64-unknown-linux-gnu` | ubuntu-latest | cargo |
| `x86_64-unknown-linux-musl` | ubuntu-latest | cross (static) |
| `aarch64-unknown-linux-gnu` | ubuntu-latest | cross |
| `x86_64-apple-darwin` | macos-13 | cargo (Intel) |
| `aarch64-apple-darwin` | macos-latest | cargo (Apple Silicon) |
| `x86_64-pc-windows-msvc` | windows-latest | cargo |

### Notes
- **No `apt-get` system deps needed.** The project has zero C build dependencies on Linux: `arboard` → pure-Rust `x11rb`, `notify-rust` → pure-Rust `zbus`, `ureq` → `rustls`. This keeps the `cross`/`musl` builds clean.
- Triggers on `release: published` (aligning with the existing `publish.yml` crates.io flow) and `workflow_dispatch`.
- `workflow_dispatch` runs build with `dry-run` (no release ref to upload to), so the manual path validates all targets without failing.
- `contents: write` is scoped to the release job only.
- README updated with a "Pre-built binaries" section under Installation.

### Verification
- Workflow YAML parses cleanly; all six matrix triples are valid rustc targets.
- `dry-run` confirmed as a valid action input; `cross` is auto-used for the aarch64/musl targets.
- Passed a Codex adversarial review (manual-dispatch soundness, token scope, and trigger interaction with `publish.yml` all addressed).