### PR TITLE
fix: make UI text follow the font color (#35)

### DIFF
--- a/crates/sigye-core/src/lib.rs
+++ b/crates/sigye-core/src/lib.rs
@@ -645,12 +645,12 @@ impl ColorTheme {
 
     /// Get a dimmed version of the current theme color for secondary text.
     pub fn secondary_color(self) -> Color {
-        dim_color(self.color(), 0.45)
+        blend_toward_gray(self.color(), 110, 0.55)
     }
 
     /// Get a brighter dimmed version of the current theme color for muted text.
     pub fn muted_color(self) -> Color {
-        dim_color(self.color(), 0.65)
+        blend_toward_gray(self.color(), 150, 0.50)
     }
 
     /// Check if this theme requires per-character coloring.
@@ -1039,6 +1039,14 @@ pub fn dim_color(color: Color, factor: f32) -> Color {
     )
 }
 
+/// Blend a color toward neutral gray while retaining some theme tint.
+pub fn blend_toward_gray(color: Color, baseline: u8, tint: f32) -> Color {
+    let tint = tint.clamp(0.0, 1.0);
+    let (r, g, b) = color_to_rgb(color);
+    let mix = |channel: u8| (baseline as f32 * (1.0 - tint) + channel as f32 * tint).round() as u8;
+    Color::Rgb(mix(r), mix(g), mix(b))
+}
+
 /// Convert RGB to HSL.
 fn rgb_to_hsl(r: u8, g: u8, b: u8) -> (f32, f32, f32) {
     let r = r as f32 / 255.0;
@@ -1124,6 +1132,32 @@ pub fn is_colon_visible(elapsed_ms: u64) -> bool {
 mod tests {
     use super::*;
 
+    const TEST_THEMES: &[ColorTheme] = &[
+        ColorTheme::Cyan,
+        ColorTheme::Green,
+        ColorTheme::White,
+        ColorTheme::Magenta,
+        ColorTheme::Yellow,
+        ColorTheme::Red,
+        ColorTheme::Blue,
+        ColorTheme::Rainbow,
+        ColorTheme::RainbowVertical,
+        ColorTheme::GradientWarm,
+        ColorTheme::GradientCool,
+        ColorTheme::GradientOcean,
+        ColorTheme::GradientNeon,
+        ColorTheme::GradientFire,
+        ColorTheme::GradientFrost,
+        ColorTheme::GradientAurora,
+        ColorTheme::GradientWinter,
+        ColorTheme::GradientSakura,
+    ];
+
+    fn luminance(color: Color) -> f32 {
+        let (r, g, b) = color_to_rgb(color);
+        0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32
+    }
+
     #[test]
     fn color_to_rgb_maps_named_colors_used_by_app() {
         let cases = [
@@ -1168,8 +1202,43 @@ mod tests {
     }
 
     #[test]
-    fn color_theme_provides_secondary_and_muted_colors() {
-        assert_eq!(ColorTheme::Cyan.secondary_color(), Color::Rgb(0, 114, 114));
-        assert_eq!(ColorTheme::Cyan.muted_color(), Color::Rgb(0, 165, 165));
+    fn blend_toward_gray_mixes_theme_with_baseline_and_clamps_tint() {
+        assert_eq!(
+            blend_toward_gray(Color::Blue, 110, 0.55),
+            Color::Rgb(50, 50, 190)
+        );
+        assert_eq!(
+            blend_toward_gray(Color::Rgb(10, 20, 30), 110, -1.0),
+            Color::Rgb(110, 110, 110)
+        );
+        assert_eq!(
+            blend_toward_gray(Color::Rgb(10, 20, 30), 110, 2.0),
+            Color::Rgb(10, 20, 30)
+        );
+    }
+
+    #[test]
+    fn color_theme_provides_contrast_aware_secondary_and_muted_colors() {
+        assert_eq!(ColorTheme::Cyan.secondary_color(), Color::Rgb(50, 190, 190));
+        assert_eq!(ColorTheme::Cyan.muted_color(), Color::Rgb(75, 203, 203));
+    }
+
+    #[test]
+    fn secondary_and_muted_colors_stay_readable_for_every_theme() {
+        for theme in TEST_THEMES {
+            let secondary_luminance = luminance(theme.secondary_color());
+            let muted_luminance = luminance(theme.muted_color());
+
+            assert!(
+                secondary_luminance >= 50.0,
+                "{} secondary luminance {secondary_luminance}",
+                theme.display_name()
+            );
+            assert!(
+                muted_luminance >= secondary_luminance,
+                "{} muted luminance {muted_luminance} < secondary {secondary_luminance}",
+                theme.display_name()
+            );
+        }
     }
 }

--- a/crates/sigye-core/src/lib.rs
+++ b/crates/sigye-core/src/lib.rs
@@ -643,6 +643,16 @@ impl ColorTheme {
         }
     }
 
+    /// Get a dimmed version of the current theme color for secondary text.
+    pub fn secondary_color(self) -> Color {
+        dim_color(self.color(), 0.45)
+    }
+
+    /// Get a brighter dimmed version of the current theme color for muted text.
+    pub fn muted_color(self) -> Color {
+        dim_color(self.color(), 0.65)
+    }
+
     /// Check if this theme requires per-character coloring.
     pub fn is_dynamic(self) -> bool {
         matches!(
@@ -994,19 +1004,39 @@ fn apply_reactive(color: Color, flash_intensity: f32) -> Color {
     )
 }
 
-/// Extract RGB values from a Color.
-fn color_to_rgb(color: Color) -> (u8, u8, u8) {
+/// Extract RGB values from a color.
+pub fn color_to_rgb(color: Color) -> (u8, u8, u8) {
     match color {
         Color::Rgb(r, g, b) => (r, g, b),
+        Color::Black => (0, 0, 0),
         Color::Red => (255, 0, 0),
         Color::Green => (0, 255, 0),
         Color::Blue => (0, 0, 255),
         Color::Yellow => (255, 255, 0),
         Color::Magenta => (255, 0, 255),
         Color::Cyan => (0, 255, 255),
+        Color::Gray => (128, 128, 128),
+        Color::DarkGray => (80, 80, 80),
+        Color::LightRed => (255, 85, 85),
+        Color::LightGreen => (85, 255, 85),
+        Color::LightYellow => (255, 255, 85),
+        Color::LightBlue => (85, 85, 255),
+        Color::LightMagenta => (255, 85, 255),
+        Color::LightCyan => (85, 255, 255),
         Color::White => (255, 255, 255),
         _ => (128, 128, 128),
     }
+}
+
+/// Scale a color's RGB channels by a clamped factor.
+pub fn dim_color(color: Color, factor: f32) -> Color {
+    let factor = factor.clamp(0.0, 1.0);
+    let (r, g, b) = color_to_rgb(color);
+    Color::Rgb(
+        (r as f32 * factor) as u8,
+        (g as f32 * factor) as u8,
+        (b as f32 * factor) as u8,
+    )
 }
 
 /// Convert RGB to HSL.
@@ -1088,4 +1118,58 @@ fn hue_to_rgb(p: f32, q: f32, mut t: f32) -> f32 {
 pub fn is_colon_visible(elapsed_ms: u64) -> bool {
     let phase = (elapsed_ms % 1000) as f32 / 1000.0;
     phase < 0.5
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_to_rgb_maps_named_colors_used_by_app() {
+        let cases = [
+            (Color::Cyan, (0, 255, 255)),
+            (Color::Green, (0, 255, 0)),
+            (Color::White, (255, 255, 255)),
+            (Color::Magenta, (255, 0, 255)),
+            (Color::Yellow, (255, 255, 0)),
+            (Color::Red, (255, 0, 0)),
+            (Color::Blue, (0, 0, 255)),
+            (Color::Gray, (128, 128, 128)),
+            (Color::DarkGray, (80, 80, 80)),
+            (Color::Black, (0, 0, 0)),
+            (Color::LightRed, (255, 85, 85)),
+            (Color::LightGreen, (85, 255, 85)),
+            (Color::LightYellow, (255, 255, 85)),
+            (Color::LightBlue, (85, 85, 255)),
+            (Color::LightMagenta, (255, 85, 255)),
+            (Color::LightCyan, (85, 255, 255)),
+        ];
+
+        for (color, expected) in cases {
+            assert_eq!(color_to_rgb(color), expected);
+        }
+    }
+
+    #[test]
+    fn color_to_rgb_passes_through_rgb_and_defaults_indexed_reset_to_gray() {
+        assert_eq!(color_to_rgb(Color::Rgb(12, 34, 56)), (12, 34, 56));
+        assert_eq!(color_to_rgb(Color::Indexed(7)), (128, 128, 128));
+        assert_eq!(color_to_rgb(Color::Reset), (128, 128, 128));
+    }
+
+    #[test]
+    fn dim_color_scales_rgb_channels_and_clamps_factor() {
+        assert_eq!(
+            dim_color(Color::Rgb(200, 100, 50), 0.5),
+            Color::Rgb(100, 50, 25)
+        );
+        assert_eq!(dim_color(Color::Red, 2.0), Color::Rgb(255, 0, 0));
+        assert_eq!(dim_color(Color::Blue, -1.0), Color::Rgb(0, 0, 0));
+    }
+
+    #[test]
+    fn color_theme_provides_secondary_and_muted_colors() {
+        assert_eq!(ColorTheme::Cyan.secondary_color(), Color::Rgb(0, 114, 114));
+        assert_eq!(ColorTheme::Cyan.muted_color(), Color::Rgb(0, 165, 165));
+    }
 }

--- a/crates/sigye-core/src/lib.rs
+++ b/crates/sigye-core/src/lib.rs
@@ -645,12 +645,12 @@ impl ColorTheme {
 
     /// Get a dimmed version of the current theme color for secondary text.
     pub fn secondary_color(self) -> Color {
-        blend_toward_gray(self.color(), 110, 0.55)
+        ensure_min_contrast_on_black(blend_toward_gray(self.color(), 110, 0.55), 3.0)
     }
 
     /// Get a brighter dimmed version of the current theme color for muted text.
     pub fn muted_color(self) -> Color {
-        blend_toward_gray(self.color(), 150, 0.50)
+        ensure_min_contrast_on_black(blend_toward_gray(self.color(), 150, 0.50), 4.5)
     }
 
     /// Check if this theme requires per-character coloring.
@@ -1047,6 +1047,52 @@ pub fn blend_toward_gray(color: Color, baseline: u8, tint: f32) -> Color {
     Color::Rgb(mix(r), mix(g), mix(b))
 }
 
+/// Convert one 8-bit sRGB channel to linear light.
+fn srgb_channel_to_linear(channel: u8) -> f32 {
+    let channel = channel as f32 / 255.0;
+    if channel <= 0.03928 {
+        channel / 12.92
+    } else {
+        ((channel + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// WCAG relative luminance of a color.
+pub fn relative_luminance(color: Color) -> f32 {
+    let (r, g, b) = color_to_rgb(color);
+    0.2126 * srgb_channel_to_linear(r)
+        + 0.7152 * srgb_channel_to_linear(g)
+        + 0.0722 * srgb_channel_to_linear(b)
+}
+
+/// WCAG contrast ratio of a color against pure black.
+pub fn contrast_ratio_on_black(color: Color) -> f32 {
+    (relative_luminance(color) + 0.05) / 0.05
+}
+
+/// Lighten a color toward white until it meets a minimum contrast ratio on black.
+pub fn ensure_min_contrast_on_black(color: Color, min_ratio: f32) -> Color {
+    let (r, g, b) = color_to_rgb(color);
+    let color = Color::Rgb(r, g, b);
+    if contrast_ratio_on_black(color) >= min_ratio {
+        return color;
+    }
+
+    let lerp = |channel: u8, t: f32| (channel as f32 + (255.0 - channel as f32) * t).round() as u8;
+    let (mut lo, mut hi) = (0.0_f32, 1.0_f32);
+    for _ in 0..16 {
+        let mid = (lo + hi) / 2.0;
+        let candidate = Color::Rgb(lerp(r, mid), lerp(g, mid), lerp(b, mid));
+        if contrast_ratio_on_black(candidate) >= min_ratio {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+
+    Color::Rgb(lerp(r, hi), lerp(g, hi), lerp(b, hi))
+}
+
 /// Convert RGB to HSL.
 fn rgb_to_hsl(r: u8, g: u8, b: u8) -> (f32, f32, f32) {
     let r = r as f32 / 255.0;
@@ -1153,11 +1199,6 @@ mod tests {
         ColorTheme::GradientSakura,
     ];
 
-    fn luminance(color: Color) -> f32 {
-        let (r, g, b) = color_to_rgb(color);
-        0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32
-    }
-
     #[test]
     fn color_to_rgb_maps_named_colors_used_by_app() {
         let cases = [
@@ -1218,25 +1259,38 @@ mod tests {
     }
 
     #[test]
-    fn color_theme_provides_contrast_aware_secondary_and_muted_colors() {
-        assert_eq!(ColorTheme::Cyan.secondary_color(), Color::Rgb(50, 190, 190));
-        assert_eq!(ColorTheme::Cyan.muted_color(), Color::Rgb(75, 203, 203));
+    fn ensure_min_contrast_keeps_bright_colors_and_lightens_dark_colors() {
+        assert_eq!(
+            ensure_min_contrast_on_black(Color::White, 4.5),
+            Color::Rgb(255, 255, 255)
+        );
+
+        let dark = Color::Rgb(0, 0, 60);
+        let adjusted = ensure_min_contrast_on_black(dark, 4.5);
+
+        assert!(contrast_ratio_on_black(adjusted) >= 4.5);
+        assert_ne!(adjusted, dark);
     }
 
     #[test]
-    fn secondary_and_muted_colors_stay_readable_for_every_theme() {
+    fn secondary_and_muted_colors_meet_wcag_contrast_floor_for_every_theme() {
         for theme in TEST_THEMES {
-            let secondary_luminance = luminance(theme.secondary_color());
-            let muted_luminance = luminance(theme.muted_color());
+            let secondary_contrast = contrast_ratio_on_black(theme.secondary_color());
+            let muted_contrast = contrast_ratio_on_black(theme.muted_color());
 
             assert!(
-                secondary_luminance >= 50.0,
-                "{} secondary luminance {secondary_luminance}",
+                secondary_contrast >= 3.0,
+                "{} secondary contrast {secondary_contrast}",
                 theme.display_name()
             );
             assert!(
-                muted_luminance >= secondary_luminance,
-                "{} muted luminance {muted_luminance} < secondary {secondary_luminance}",
+                muted_contrast >= 4.5,
+                "{} muted contrast {muted_contrast}",
+                theme.display_name()
+            );
+            assert!(
+                muted_contrast >= secondary_contrast,
+                "{} muted contrast {muted_contrast} < secondary {secondary_contrast}",
                 theme.display_name()
             );
         }

--- a/crates/sigye/src/context.rs
+++ b/crates/sigye/src/context.rs
@@ -34,6 +34,16 @@ impl RenderContext {
         self.color_theme.color()
     }
 
+    /// Get the dimmed theme color for secondary text.
+    pub fn dim_color(&self) -> Color {
+        self.color_theme.secondary_color()
+    }
+
+    /// Get the muted theme color for slightly brighter secondary text.
+    pub fn muted_color(&self) -> Color {
+        self.color_theme.muted_color()
+    }
+
     /// Get animation elapsed time in milliseconds.
     pub fn elapsed_ms(&self) -> u64 {
         self.animation_start.elapsed().as_millis() as u64

--- a/crates/sigye/src/countdown_dialog.rs
+++ b/crates/sigye/src/countdown_dialog.rs
@@ -255,11 +255,12 @@ impl CountdownDialog {
                     form.name.pop();
                     self.error = None;
                 }
-                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    if form.name.chars().count() < NAME_MAX {
-                        form.name.push(c);
-                        self.error = None;
-                    }
+                KeyCode::Char(c)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL)
+                        && form.name.chars().count() < NAME_MAX =>
+                {
+                    form.name.push(c);
+                    self.error = None;
                 }
                 _ => {}
             },
@@ -268,11 +269,12 @@ impl CountdownDialog {
                     form.target.pop();
                     self.error = None;
                 }
-                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    if form.target.chars().count() < TARGET_MAX {
-                        form.target.push(c);
-                        self.error = None;
-                    }
+                KeyCode::Char(c)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL)
+                        && form.target.chars().count() < TARGET_MAX =>
+                {
+                    form.target.push(c);
+                    self.error = None;
                 }
                 _ => {}
             },

--- a/crates/sigye/src/countdown_dialog.rs
+++ b/crates/sigye/src/countdown_dialog.rs
@@ -289,17 +289,17 @@ impl CountdownDialog {
     }
 
     /// Render the dialog (list or edit view depending on state).
-    pub fn render(&self, frame: &mut Frame, area: Rect, accent: Color) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, accent: Color, dim: Color, muted: Color) {
         if !self.visible {
             return;
         }
         match self.view {
-            View::List => self.render_list(frame, area, accent),
-            View::Edit => self.render_edit(frame, area, accent),
+            View::List => self.render_list(frame, area, accent, dim, muted),
+            View::Edit => self.render_edit(frame, area, accent, dim, muted),
         }
     }
 
-    fn render_list(&self, frame: &mut Frame, area: Rect, accent: Color) {
+    fn render_list(&self, frame: &mut Frame, area: Rect, accent: Color, dim: Color, muted: Color) {
         let dialog_width = 60u16.min(area.width.saturating_sub(4));
         // border(2) + padding(2) + title(1) + entries (cap 10) + help(2)
         let row_count = self.events.len().clamp(1, 10) as u16;
@@ -329,14 +329,11 @@ impl CountdownDialog {
         if self.events.is_empty() {
             let lines = vec![
                 Line::from(""),
-                Line::from(Span::styled(
-                    "No events yet.",
-                    Style::default().fg(Color::Gray),
-                ))
-                .alignment(Alignment::Center),
+                Line::from(Span::styled("No events yet.", Style::default().fg(muted)))
+                    .alignment(Alignment::Center),
                 Line::from(Span::styled(
                     "Press [a] to add your first one.",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(dim),
                 ))
                 .alignment(Alignment::Center),
             ];
@@ -351,14 +348,11 @@ impl CountdownDialog {
                 let style = if is_selected {
                     Style::default().fg(accent).bold()
                 } else {
-                    Style::default().fg(Color::Gray)
+                    Style::default().fg(muted)
                 };
                 lines.push(Line::from(vec![
                     Span::styled(main, style),
-                    Span::styled(
-                        format!("  {direction}"),
-                        Style::default().fg(Color::DarkGray),
-                    ),
+                    Span::styled(format!("  {direction}"), Style::default().fg(dim)),
                 ]));
             }
             frame.render_widget(Paragraph::new(lines), list_area);
@@ -366,19 +360,19 @@ impl CountdownDialog {
 
         let help_a = Line::from(vec![
             Span::styled("↑↓", Style::default().fg(accent).bold()),
-            Span::styled(" nav  ", Style::default().fg(Color::Gray)),
+            Span::styled(" nav  ", Style::default().fg(muted)),
             Span::styled("a", Style::default().fg(accent).bold()),
-            Span::styled(" add  ", Style::default().fg(Color::Gray)),
+            Span::styled(" add  ", Style::default().fg(muted)),
             Span::styled("e", Style::default().fg(accent).bold()),
-            Span::styled(" edit  ", Style::default().fg(Color::Gray)),
+            Span::styled(" edit  ", Style::default().fg(muted)),
             Span::styled("d", Style::default().fg(accent).bold()),
-            Span::styled(" delete", Style::default().fg(Color::Gray)),
+            Span::styled(" delete", Style::default().fg(muted)),
         ]);
         let help_b = Line::from(vec![
             Span::styled("Enter", Style::default().fg(accent).bold()),
-            Span::styled(" save  ", Style::default().fg(Color::Gray)),
+            Span::styled(" save  ", Style::default().fg(muted)),
             Span::styled("Esc", Style::default().fg(accent).bold()),
-            Span::styled(" cancel", Style::default().fg(Color::Gray)),
+            Span::styled(" cancel", Style::default().fg(muted)),
         ]);
         frame.render_widget(
             Paragraph::new(help_a).alignment(Alignment::Center),
@@ -390,7 +384,7 @@ impl CountdownDialog {
         );
     }
 
-    fn render_edit(&self, frame: &mut Frame, area: Rect, accent: Color) {
+    fn render_edit(&self, frame: &mut Frame, area: Rect, accent: Color, dim: Color, muted: Color) {
         let form = match self.form.as_ref() {
             Some(f) => f,
             None => return,
@@ -436,6 +430,7 @@ impl CountdownDialog {
                 &form.name,
                 form.field == FormField::Name,
                 accent,
+                muted,
             )),
             row_area(1),
         );
@@ -445,13 +440,14 @@ impl CountdownDialog {
                 &form.target,
                 form.field == FormField::Target,
                 accent,
+                muted,
             )),
             row_area(2),
         );
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(
                 "         e.g. 2026-06-01  or  2026-06-01T09:00:00+09:00",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(dim),
             ))),
             row_area(3),
         );
@@ -461,6 +457,7 @@ impl CountdownDialog {
                 form.since,
                 form.field == FormField::Since,
                 accent,
+                muted,
             )),
             row_area(4),
         );
@@ -478,11 +475,11 @@ impl CountdownDialog {
 
         let help = Line::from(vec![
             Span::styled("Tab", Style::default().fg(accent).bold()),
-            Span::styled(" field  ", Style::default().fg(Color::Gray)),
+            Span::styled(" field  ", Style::default().fg(muted)),
             Span::styled("Enter", Style::default().fg(accent).bold()),
-            Span::styled(" commit  ", Style::default().fg(Color::Gray)),
+            Span::styled(" commit  ", Style::default().fg(muted)),
             Span::styled("Esc", Style::default().fg(accent).bold()),
-            Span::styled(" cancel", Style::default().fg(Color::Gray)),
+            Span::styled(" cancel", Style::default().fg(muted)),
         ]);
         frame.render_widget(Paragraph::new(help).alignment(Alignment::Center), chunks[8]);
     }
@@ -493,11 +490,12 @@ impl CountdownDialog {
         value: &str,
         focused: bool,
         accent: Color,
+        muted: Color,
     ) -> Line<'static> {
         let label_style = if focused {
             Style::default().fg(accent).bold()
         } else {
-            Style::default().fg(Color::Gray)
+            Style::default().fg(muted)
         };
         let field_style = if focused {
             Style::default().fg(Color::White).bg(Color::Rgb(40, 40, 40))
@@ -518,11 +516,12 @@ impl CountdownDialog {
         value: bool,
         focused: bool,
         accent: Color,
+        muted: Color,
     ) -> Line<'static> {
         let label_style = if focused {
             Style::default().fg(accent).bold()
         } else {
-            Style::default().fg(Color::Gray)
+            Style::default().fg(muted)
         };
         let toggle = if value {
             "[x] count up"
@@ -560,6 +559,7 @@ fn inset(area: Rect, padding: u16) -> Rect {
 mod tests {
     use super::*;
     use crossterm::event::{KeyEventKind, KeyEventState, KeyModifiers};
+    use ratatui::{Terminal, backend::TestBackend};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent {
@@ -708,5 +708,72 @@ mod tests {
         d.handle_key(key(KeyCode::Char(' ')));
         d.handle_key(key(KeyCode::Enter));
         assert!(d.events[0].since);
+    }
+
+    #[test]
+    fn render_list_uses_dim_and_muted_for_secondary_text() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        let mut d = CountdownDialog::new();
+        d.open(vec![CountdownEvent {
+            name: "Launch".into(),
+            target: "2026-06-01".into(),
+            since: false,
+        }]);
+        let accent = Color::Red;
+        let dim = Color::Rgb(10, 20, 30);
+        let muted = Color::Rgb(40, 50, 60);
+
+        terminal
+            .draw(|frame| d.render(frame, frame.area(), accent, dim, muted))
+            .unwrap();
+
+        let backend = terminal.backend();
+        assert_eq!(color_of_text(backend, " until"), Some(dim));
+        assert_eq!(color_of_text(backend, " nav  "), Some(muted));
+    }
+
+    #[test]
+    fn render_edit_keeps_inputs_white_and_uses_dim_for_hint() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        let mut d = CountdownDialog::new();
+        d.open(vec![]);
+        d.handle_key(key(KeyCode::Char('a')));
+        for c in "Launch".chars() {
+            d.handle_key(key(KeyCode::Char(c)));
+        }
+        let accent = Color::Red;
+        let dim = Color::Rgb(10, 20, 30);
+        let muted = Color::Rgb(40, 50, 60);
+
+        terminal
+            .draw(|frame| d.render(frame, frame.area(), accent, dim, muted))
+            .unwrap();
+
+        let backend = terminal.backend();
+        assert_eq!(color_of_text(backend, "e.g. 2026-06-01"), Some(dim));
+        assert_eq!(color_of_text(backend, "Launch"), Some(Color::White));
+        assert_eq!(color_of_text(backend, " field  "), Some(muted));
+    }
+
+    fn color_of_text(backend: &TestBackend, text: &str) -> Option<Color> {
+        let buffer = backend.buffer();
+        let area = buffer.area;
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if text_matches_at(backend, x, y, text) {
+                    return buffer.cell((x, y)).map(|cell| cell.fg);
+                }
+            }
+        }
+        None
+    }
+
+    fn text_matches_at(backend: &TestBackend, x: u16, y: u16, text: &str) -> bool {
+        let buffer = backend.buffer();
+        text.chars().enumerate().all(|(offset, ch)| {
+            buffer
+                .cell((x + offset as u16, y))
+                .is_some_and(|cell| cell.symbol() == ch.to_string())
+        })
     }
 }

--- a/crates/sigye/src/main.rs
+++ b/crates/sigye/src/main.rs
@@ -439,15 +439,19 @@ impl App {
 
         // Render dialogs (last visible wins) — settings, then mode picker, then countdown editor.
         let color = self.ctx.color();
+        let dim = self.ctx.dim_color();
+        let muted = self.ctx.muted_color();
         let area = frame.area();
-        self.settings_dialog.render(frame, area, color);
+        self.settings_dialog.render(frame, area, color, dim, muted);
         self.mode_dialog.render(
             frame,
             area,
             color,
+            dim,
+            muted,
             self.modes[self.active_mode_index].display_mode(),
         );
-        self.countdown_dialog.render(frame, area, color);
+        self.countdown_dialog.render(frame, area, color, dim, muted);
 
         // Render help overlay
         self.render_help_overlay(frame);
@@ -747,7 +751,7 @@ impl App {
 
         let accent = self.ctx.color();
         let fg = Color::White;
-        let dim = Color::Gray;
+        let dim = self.ctx.muted_color();
 
         let key_line = |key: &'static str, desc: &'static str| -> Line<'static> {
             Line::from(vec![

--- a/crates/sigye/src/mode_dialog.rs
+++ b/crates/sigye/src/mode_dialog.rs
@@ -92,7 +92,15 @@ impl ModeDialog {
     }
 
     /// Render the dialog. `current` marks the active mode with a dot.
-    pub fn render(&self, frame: &mut Frame, area: Rect, accent: Color, current: DisplayMode) {
+    pub fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        accent: Color,
+        _dim: Color,
+        muted: Color,
+        current: DisplayMode,
+    ) {
         if !self.visible {
             return;
         }
@@ -139,7 +147,7 @@ impl ModeDialog {
             } else if is_current {
                 Style::default().fg(Color::White)
             } else {
-                Style::default().fg(Color::Gray)
+                Style::default().fg(muted)
             };
 
             lines.push(Line::from(vec![
@@ -158,13 +166,13 @@ impl ModeDialog {
 
         let help = Line::from(vec![
             Span::styled("↑↓", Style::default().fg(accent).bold()),
-            Span::styled(" nav  ", Style::default().fg(Color::Gray)),
+            Span::styled(" nav  ", Style::default().fg(muted)),
             Span::styled("1-6", Style::default().fg(accent).bold()),
-            Span::styled(" jump  ", Style::default().fg(Color::Gray)),
+            Span::styled(" jump  ", Style::default().fg(muted)),
             Span::styled("Enter", Style::default().fg(accent).bold()),
-            Span::styled(" pick  ", Style::default().fg(Color::Gray)),
+            Span::styled(" pick  ", Style::default().fg(muted)),
             Span::styled("Esc", Style::default().fg(accent).bold()),
-            Span::styled(" cancel", Style::default().fg(Color::Gray)),
+            Span::styled(" cancel", Style::default().fg(muted)),
         ]);
         frame.render_widget(Paragraph::new(help).alignment(Alignment::Center), chunks[3]);
     }
@@ -174,6 +182,7 @@ impl ModeDialog {
 mod tests {
     use super::*;
     use crossterm::event::{KeyEventKind, KeyEventState, KeyModifiers};
+    use ratatui::{Terminal, backend::TestBackend};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent {
@@ -232,5 +241,43 @@ mod tests {
         d.open(DisplayMode::Clock);
         d.handle_key(key(KeyCode::Up));
         assert_eq!(MODES[d.selected], DisplayMode::Countdown);
+    }
+
+    #[test]
+    fn render_uses_muted_for_secondary_help_text() {
+        let mut terminal = Terminal::new(TestBackend::new(50, 16)).unwrap();
+        let mut d = ModeDialog::new();
+        d.open(DisplayMode::Clock);
+        let accent = Color::Red;
+        let dim = Color::Rgb(10, 20, 30);
+        let muted = Color::Rgb(40, 50, 60);
+
+        terminal
+            .draw(|frame| d.render(frame, frame.area(), accent, dim, muted, DisplayMode::Clock))
+            .unwrap();
+
+        assert_eq!(color_of_text(terminal.backend(), " nav  "), Some(muted));
+    }
+
+    fn color_of_text(backend: &TestBackend, text: &str) -> Option<Color> {
+        let buffer = backend.buffer();
+        let area = buffer.area;
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if text_matches_at(backend, x, y, text) {
+                    return buffer.cell((x, y)).map(|cell| cell.fg);
+                }
+            }
+        }
+        None
+    }
+
+    fn text_matches_at(backend: &TestBackend, x: u16, y: u16, text: &str) -> bool {
+        let buffer = backend.buffer();
+        text.chars().enumerate().all(|(offset, ch)| {
+            buffer
+                .cell((x + offset as u16, y))
+                .is_some_and(|cell| cell.symbol() == ch.to_string())
+        })
     }
 }

--- a/crates/sigye/src/modes/clock.rs
+++ b/crates/sigye/src/modes/clock.rs
@@ -10,7 +10,7 @@ use ratatui::{
     layout::{Constraint, Layout, Position, Rect},
     style::Color,
 };
-use sigye_core::{ClockDisplayFormat, DisplayMode, TimeFormat};
+use sigye_core::{ClockDisplayFormat, DisplayMode, TimeFormat, color_to_rgb};
 
 use crate::context::RenderContext;
 use crate::mode::Mode;
@@ -174,17 +174,7 @@ fn render_toast(frame: &mut Frame, area: Rect, text: &str, accent: Color, elapse
         1.0
     };
 
-    let (r, g, b) = match accent {
-        Color::Rgb(r, g, b) => (r, g, b),
-        Color::Cyan => (0, 255, 255),
-        Color::Green => (0, 255, 0),
-        Color::Magenta => (255, 0, 255),
-        Color::Yellow => (255, 255, 0),
-        Color::Red => (255, 0, 0),
-        Color::Blue => (0, 0, 255),
-        Color::White => (255, 255, 255),
-        _ => (128, 128, 128),
-    };
+    let (r, g, b) = color_to_rgb(accent);
 
     let faded = Color::Rgb(
         (r as f32 * opacity) as u8,
@@ -310,26 +300,26 @@ impl Mode for ClockMode {
 
         // Render date string
         let date_str = now.format("%A, %B %-d, %Y").to_string();
-        render::render_centered_text(frame, chunks[3], &date_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[3], &date_str, ctx.dim_color());
 
         // Render sunrise/sunset info if available
         if let Some((ref sunrise, ref sunset)) = ctx.sunrise_sunset {
             let sun_str = format!("Sunrise {}  Sunset {}", sunrise, sunset);
-            render::render_centered_text(frame, chunks[4], &sun_str, Color::DarkGray);
+            render::render_centered_text(frame, chunks[4], &sun_str, ctx.dim_color());
         }
 
         // Render format info line
         match self.display_format {
             ClockDisplayFormat::HumanReadable => {}
             ClockDisplayFormat::UnixTimestamp => {
-                render::render_centered_text(frame, chunks[5], "Unix Timestamp", Color::DarkGray);
+                render::render_centered_text(frame, chunks[5], "Unix Timestamp", ctx.dim_color());
             }
             ClockDisplayFormat::Iso8601 => {
                 let iso = now.format("%Y-%m-%dT%H:%M:%S%:z").to_string();
-                render::render_centered_text(frame, chunks[5], &iso, Color::Gray);
+                render::render_centered_text(frame, chunks[5], &iso, ctx.muted_color());
             }
             ClockDisplayFormat::HexTime => {
-                render::render_centered_text(frame, chunks[5], "Hex Time", Color::DarkGray);
+                render::render_centered_text(frame, chunks[5], "Hex Time", ctx.dim_color());
             }
         }
 
@@ -368,7 +358,7 @@ impl Mode for ClockMode {
             let start_x = info_area.x + (info_area.width.saturating_sub(total_width)) / 2;
             let max_x = info_area.x + info_area.width;
             let y = info_area.y;
-            let dim = Color::Rgb(100, 100, 100);
+            let dim = ctx.dim_color();
 
             let buf = frame.buffer_mut();
             let after_day = render_mini_bar(
@@ -402,7 +392,7 @@ impl Mode for ClockMode {
             .map(|(k, v)| format!("[{k}] {v}"))
             .collect::<Vec<_>>()
             .join("  ");
-        render::render_centered_text(frame, chunks[8], &hint_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[8], &hint_str, ctx.dim_color());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/countdown.rs
+++ b/crates/sigye/src/modes/countdown.rs
@@ -7,7 +7,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Layout},
-    style::{Color, Style},
+    style::Style,
     text::{Line, Span},
     widgets::Paragraph,
 };
@@ -220,8 +220,8 @@ impl CountdownMode {
     fn render_onboarding(&self, frame: &mut Frame, ctx: &RenderContext) {
         let area = frame.area();
         let accent = ctx.color();
-        let dim = Color::DarkGray;
-        let muted = Color::Gray;
+        let dim = ctx.dim_color();
+        let muted = ctx.muted_color();
 
         let chunks = Layout::vertical([
             Constraint::Fill(1),   // [0] top spacer
@@ -272,7 +272,7 @@ impl CountdownMode {
             .iter()
             .map(|(name, target, kind)| {
                 Line::from(vec![
-                    Span::styled(format!("  {name:<18}"), Style::default().fg(Color::White)),
+                    Span::styled(format!("  {name:<18}"), Style::default().fg(muted)),
                     Span::styled(format!("{target:<14}"), Style::default().fg(muted)),
                     Span::styled(format!("({kind})"), Style::default().fg(dim)),
                 ])
@@ -356,11 +356,11 @@ impl Mode for CountdownMode {
 
         render::render_ascii_text(frame, chunks[1], font, &view.big_text, &params);
         render::render_centered_text(frame, chunks[3], &view.status, ctx.color());
-        render::render_centered_text(frame, chunks[4], &view.target_label, Color::DarkGray);
+        render::render_centered_text(frame, chunks[4], &view.target_label, ctx.dim_color());
 
         if events.len() > 1 {
             let pager = format!("event {} of {}", self.active_index + 1, events.len());
-            render::render_centered_text(frame, chunks[6], &pager, Color::DarkGray);
+            render::render_centered_text(frame, chunks[6], &pager, ctx.dim_color());
         }
 
         let hints = self.key_hints();
@@ -369,7 +369,7 @@ impl Mode for CountdownMode {
             .map(|(k, v)| format!("[{k}] {v}"))
             .collect::<Vec<_>>()
             .join("  ");
-        render::render_centered_text(frame, chunks[7], &hint_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[7], &hint_str, ctx.dim_color());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/pomodoro.rs
+++ b/crates/sigye/src/modes/pomodoro.rs
@@ -207,7 +207,7 @@ impl Mode for PomodoroMode {
             self.sessions_completed,
             self.total_focus_secs / 60
         );
-        render::render_centered_text(frame, chunks[3], &session_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[3], &session_str, ctx.dim_color());
 
         // Progress bar
         let total_secs = phase_duration_secs(self.phase, ctx);
@@ -227,7 +227,7 @@ impl Mode for PomodoroMode {
             .map(|(k, v)| format!("[{k}] {v}"))
             .collect::<Vec<_>>()
             .join("  ");
-        render::render_centered_text(frame, chunks[6], &hint_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[6], &hint_str, ctx.dim_color());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/stopwatch.rs
+++ b/crates/sigye/src/modes/stopwatch.rs
@@ -130,7 +130,7 @@ impl Mode for StopwatchMode {
         // Centiseconds below (dimmed)
         let centis = (elapsed % 1000) / 10;
         let centis_str = format!(".{:02}", centis);
-        render::render_centered_text(frame, chunks[2], &centis_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[2], &centis_str, ctx.dim_color());
 
         // Status
         let (status_text, status_color) = if self.running {
@@ -138,7 +138,7 @@ impl Mode for StopwatchMode {
         } else if elapsed > 0 {
             ("PAUSED", Color::Yellow)
         } else {
-            ("STOPPED", Color::DarkGray)
+            ("STOPPED", ctx.dim_color())
         };
         render::render_centered_text(frame, chunks[3], status_text, status_color);
 
@@ -176,7 +176,7 @@ impl Mode for StopwatchMode {
                     width: lap_area.width,
                     height: 1,
                 };
-                render::render_centered_text(frame, row_area, &lap_str, Color::DarkGray);
+                render::render_centered_text(frame, row_area, &lap_str, ctx.dim_color());
             }
         }
 
@@ -187,7 +187,7 @@ impl Mode for StopwatchMode {
             .map(|(k, v)| format!("[{k}] {v}"))
             .collect::<Vec<_>>()
             .join("  ");
-        render::render_centered_text(frame, chunks[6], &hint_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[6], &hint_str, ctx.dim_color());
     }
 
     fn handle_key(&mut self, key: KeyEvent, _ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/timer.rs
+++ b/crates/sigye/src/modes/timer.rs
@@ -155,7 +155,7 @@ impl Mode for TimerMode {
         let (status_text, status_color) = if self.completed {
             ("TIME'S UP!", Color::Red)
         } else if !self.running {
-            ("(PAUSED)", Color::DarkGray)
+            ("(PAUSED)", ctx.dim_color())
         } else {
             ("RUNNING", ctx.color())
         };
@@ -184,7 +184,7 @@ impl Mode for TimerMode {
             .map(|(k, v)| format!("[{k}] {v}"))
             .collect::<Vec<_>>()
             .join("  ");
-        render::render_centered_text(frame, chunks[5], &hint_str, Color::DarkGray);
+        render::render_centered_text(frame, chunks[5], &hint_str, ctx.dim_color());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/world_clock.rs
+++ b/crates/sigye/src/modes/world_clock.rs
@@ -9,7 +9,6 @@ use crossterm::event::KeyEvent;
 use ratatui::{
     Frame,
     layout::{Constraint, Layout},
-    style::Color,
 };
 use sigye_core::{DisplayMode, TimeFormat};
 
@@ -76,7 +75,7 @@ impl Mode for WorldClockMode {
                 frame,
                 area,
                 "No world clock zones configured",
-                Color::DarkGray,
+                ctx.dim_color(),
             );
             return;
         }
@@ -121,7 +120,7 @@ impl Mode for WorldClockMode {
                     .split(entry_area);
 
             // Render label
-            render::render_centered_text(frame, entry_chunks[0], label, Color::DarkGray);
+            render::render_centered_text(frame, entry_chunks[0], label, ctx.dim_color());
 
             // Render time in FIGlet font
             let time_str = if let Ok(tz) = Tz::from_str(tz_str) {
@@ -145,7 +144,7 @@ impl Mode for WorldClockMode {
             .map(|(k, v)| format!("[{k}] {v}"))
             .collect::<Vec<_>>()
             .join("  ");
-        render::render_centered_text(frame, hints_area, &hint_str, Color::DarkGray);
+        render::render_centered_text(frame, hints_area, &hint_str, ctx.dim_color());
     }
 
     fn handle_key(&mut self, _key: KeyEvent, _ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/settings.rs
+++ b/crates/sigye/src/settings.rs
@@ -78,6 +78,12 @@ enum RowKind {
     Spacer,
 }
 
+#[derive(Clone, Copy)]
+struct DialogTextColors {
+    dim: Color,
+    muted: Color,
+}
+
 /// Settings dialog state.
 #[derive(Debug)]
 pub struct SettingsDialog {
@@ -540,10 +546,18 @@ impl SettingsDialog {
     }
 
     /// Render the settings dialog.
-    pub fn render(&mut self, frame: &mut Frame, area: Rect, accent_color: Color) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        accent_color: Color,
+        dim: Color,
+        muted: Color,
+    ) {
         if !self.visible {
             return;
         }
+        let text_colors = DialogTextColors { dim, muted };
 
         let layout = Self::section_layout();
         let total_content_rows = layout.len() as u16;
@@ -623,7 +637,7 @@ impl SettingsDialog {
                     );
                 }
                 RowKind::Field(field) => {
-                    let line = self.render_field_for(*field, accent_color);
+                    let line = self.render_field_for(*field, accent_color, text_colors);
                     frame
                         .render_widget(Paragraph::new(line).alignment(Alignment::Center), row_area);
                 }
@@ -662,13 +676,13 @@ impl SettingsDialog {
         // Render help text
         let help = Line::from(vec![
             Span::styled("↑↓", Style::default().fg(accent_color).bold()),
-            Span::styled(" nav  ", Style::default().fg(Color::Gray)),
+            Span::styled(" nav  ", Style::default().fg(muted)),
             Span::styled("←→", Style::default().fg(accent_color).bold()),
-            Span::styled(" change  ", Style::default().fg(Color::Gray)),
+            Span::styled(" change  ", Style::default().fg(muted)),
             Span::styled("Enter", Style::default().fg(accent_color).bold()),
-            Span::styled(" save  ", Style::default().fg(Color::Gray)),
+            Span::styled(" save  ", Style::default().fg(muted)),
             Span::styled("Esc", Style::default().fg(accent_color).bold()),
-            Span::styled(" cancel", Style::default().fg(Color::Gray)),
+            Span::styled(" cancel", Style::default().fg(muted)),
         ]);
         frame.render_widget(Paragraph::new(help).alignment(Alignment::Center), chunks[3]);
     }
@@ -682,38 +696,49 @@ impl SettingsDialog {
     }
 
     /// Render the appropriate field line for a given SettingsField.
-    fn render_field_for(&self, field: SettingsField, accent_color: Color) -> Line<'static> {
+    fn render_field_for(
+        &self,
+        field: SettingsField,
+        accent_color: Color,
+        text_colors: DialogTextColors,
+    ) -> Line<'static> {
         let selected = self.selected_field == field;
         match field {
-            SettingsField::Font => {
-                self.render_field("Font", self.selected_font(), selected, accent_color)
-            }
+            SettingsField::Font => self.render_field(
+                "Font",
+                self.selected_font(),
+                selected,
+                accent_color,
+                text_colors.muted,
+            ),
             SettingsField::Color => self.render_field(
                 "Color",
                 self.color_theme.display_name(),
                 selected,
                 accent_color,
+                text_colors.muted,
             ),
             SettingsField::TimeFormat => {
                 let name = match self.time_format {
                     TimeFormat::TwentyFourHour => "24-hour",
                     TimeFormat::TwelveHour => "12-hour",
                 };
-                self.render_field("Format", name, selected, accent_color)
+                self.render_field("Format", name, selected, accent_color, text_colors.muted)
             }
             SettingsField::ShowSeconds => {
                 let v = if self.show_seconds { "On" } else { "Off" };
-                self.render_field("Seconds", v, selected, accent_color)
+                self.render_field("Seconds", v, selected, accent_color, text_colors.muted)
             }
             SettingsField::ColonBlink => {
                 let v = if self.colon_blink { "On" } else { "Off" };
-                self.render_field("Colon Blink", v, selected, accent_color)
+                self.render_field("Colon Blink", v, selected, accent_color, text_colors.muted)
             }
             SettingsField::Animation => self.render_field(
                 "Animation",
                 self.animation_style.display_name(),
                 selected,
                 accent_color,
+                text_colors.muted,
             ),
             SettingsField::Speed => self.render_field_with_style(
                 "Speed",
@@ -721,28 +746,30 @@ impl SettingsDialog {
                 selected,
                 accent_color,
                 self.animation_style != AnimationStyle::None,
+                text_colors,
             ),
             SettingsField::Background => self.render_field(
                 "Background",
                 self.background_style.display_name(),
                 selected,
                 accent_color,
+                text_colors.muted,
             ),
             SettingsField::PomodoroWork => {
                 let v = format!("{} min", self.pomodoro_work_mins);
-                self.render_field("Work", &v, selected, accent_color)
+                self.render_field("Work", &v, selected, accent_color, text_colors.muted)
             }
             SettingsField::PomodoroBreak => {
                 let v = format!("{} min", self.pomodoro_break_mins);
-                self.render_field("Break", &v, selected, accent_color)
+                self.render_field("Break", &v, selected, accent_color, text_colors.muted)
             }
             SettingsField::PomodoroLongBreak => {
                 let v = format!("{} min", self.pomodoro_long_break_mins);
-                self.render_field("Long Break", &v, selected, accent_color)
+                self.render_field("Long Break", &v, selected, accent_color, text_colors.muted)
             }
             SettingsField::PomodoroSound => {
                 let v = if self.pomodoro_sound { "On" } else { "Off" };
-                self.render_field("Sound", v, selected, accent_color)
+                self.render_field("Sound", v, selected, accent_color, text_colors.muted)
             }
             SettingsField::DesktopNotifications => {
                 let v = if self.desktop_notifications {
@@ -750,11 +777,17 @@ impl SettingsDialog {
                 } else {
                     "Off"
                 };
-                self.render_field("Notifications", v, selected, accent_color)
+                self.render_field(
+                    "Notifications",
+                    v,
+                    selected,
+                    accent_color,
+                    text_colors.muted,
+                )
             }
             SettingsField::TimerDuration => {
                 let v = format!("{} min", self.timer_duration_mins);
-                self.render_field("Duration", &v, selected, accent_color)
+                self.render_field("Duration", &v, selected, accent_color, text_colors.muted)
             }
         }
     }
@@ -766,6 +799,7 @@ impl SettingsDialog {
         value: &str,
         selected: bool,
         accent_color: Color,
+        muted: Color,
     ) -> Line<'static> {
         if selected {
             let arrow_style = Style::default().fg(accent_color).bold();
@@ -779,7 +813,7 @@ impl SettingsDialog {
                 Span::styled(String::from(" ▶"), arrow_style),
             ])
         } else {
-            let label_style = Style::default().fg(Color::Gray);
+            let label_style = Style::default().fg(muted);
             let value_style = Style::default().fg(Color::White);
             Line::from(vec![
                 Span::styled(String::from("  "), Style::default()),
@@ -797,10 +831,11 @@ impl SettingsDialog {
         selected: bool,
         accent_color: Color,
         enabled: bool,
+        text_colors: DialogTextColors,
     ) -> Line<'static> {
         if !enabled {
             // Grayed out when disabled - no arrows
-            let gray = Style::default().fg(Color::DarkGray);
+            let gray = Style::default().fg(text_colors.dim);
             return Line::from(vec![
                 Span::styled(String::from("  "), Style::default()),
                 Span::styled(format!("{label}: "), gray),
@@ -808,6 +843,69 @@ impl SettingsDialog {
             ]);
         }
 
-        self.render_field(label, value, selected, accent_color)
+        self.render_field(label, value, selected, accent_color, text_colors.muted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn render_uses_dim_and_muted_for_secondary_text() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 30)).unwrap();
+        let mut dialog = SettingsDialog::new(vec!["Standard".into()]);
+        dialog.open(
+            "Standard",
+            ColorTheme::Cyan,
+            TimeFormat::TwentyFourHour,
+            AnimationStyle::None,
+            AnimationSpeed::Medium,
+            true,
+            true,
+            BackgroundStyle::None,
+            25,
+            5,
+            15,
+            true,
+            true,
+            5,
+        );
+        let accent = Color::Red;
+        let dim = Color::Rgb(10, 20, 30);
+        let muted = Color::Rgb(40, 50, 60);
+
+        terminal
+            .draw(|frame| dialog.render(frame, frame.area(), accent, dim, muted))
+            .unwrap();
+
+        let backend = terminal.backend();
+        assert_eq!(color_of_text(backend, "Color: "), Some(muted));
+        assert_eq!(color_of_text(backend, "Speed: "), Some(dim));
+        assert_eq!(color_of_text(backend, " nav  "), Some(muted));
+        assert_eq!(color_of_text(backend, "Cyan"), Some(Color::White));
+    }
+
+    fn color_of_text(backend: &TestBackend, text: &str) -> Option<Color> {
+        let buffer = backend.buffer();
+        let area = buffer.area;
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if text_matches_at(backend, x, y, text) {
+                    return buffer.cell((x, y)).map(|cell| cell.fg);
+                }
+            }
+        }
+        None
+    }
+
+    fn text_matches_at(backend: &TestBackend, x: u16, y: u16, text: &str) -> bool {
+        let buffer = backend.buffer();
+        text.chars().enumerate().all(|(offset, ch)| {
+            buffer
+                .cell((x + offset as u16, y))
+                .is_some_and(|cell| cell.symbol() == ch.to_string())
+        })
     }
 }


### PR DESCRIPTION
Fixes #35

## Problem
Changing the font color (`color_theme`) only recolored the big ASCII clock text and the Day/Year progress bars. All other UI text — date, sunrise/sunset, format info, key hints, world-clock labels, stopwatch laps/centiseconds, countdown labels, and the dialogs/help overlay — was hardcoded to `Color::DarkGray` / `Color::Gray`, so it never responded to the setting.

## Fix
Secondary/auxiliary UI text now follows the selected font color, dimmed so the clock stays the focus and visual hierarchy is preserved. Genuine semantic colors (red TIME'S UP, green/yellow stopwatch states, pomodoro phase colors, error red) are left unchanged.

- **`sigye-core`**: `color_to_rgb` made public; added `blend_toward_gray` plus WCAG helpers `relative_luminance` / `contrast_ratio_on_black` / `ensure_min_contrast_on_black`. `ColorTheme::secondary_color` / `muted_color` derive theme-tinted colors that enforce a WCAG contrast floor on the black background (secondary ≥ 3.0:1, muted ≥ 4.5:1) so even low-luminance themes like Blue stay readable while keeping their hue.
- **`context`**: added `ctx.dim_color()` / `ctx.muted_color()` accessors.
- **modes** (clock, pomodoro, timer, stopwatch, world_clock, countdown): replaced hardcoded gray/white auxiliary text with the theme-derived dim/muted colors.
- **dialogs** (countdown, mode picker, settings) + **help overlay**: threaded dim/muted theme colors through the render paths; replaced `Gray → muted`, `DarkGray → dim`, keeping white editable field values and semantic colors.
- Incidental: collapsed two pre-existing `collapsible_match` clippy lints in `countdown_dialog.rs` so the workspace passes `clippy -D warnings`.

## Testing
- `cargo build` — clean
- `cargo test` — 40 tests pass (new core color tests with per-theme WCAG contrast-floor assertions; render tests for all three dialogs)
- `cargo clippy --all-targets -- -D warnings` — clean

## Worst-case contrast (Blue theme, the only one needing lightening)
- secondary `Rgb(72,72,197)` — 3.01:1 (was 2.34:1 with naive dimming)
- muted `Rgb(104,104,211)` — 4.51:1

All other themes already clear both floors from the tint blend alone, so their hues are fully preserved.

🤖 Reviewed with Codex adversarial review (final verdict: approve).