### PR TITLE
fix: hide key hints in screensaver mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.worktrees/

--- a/crates/sigye/src/modes/clock.rs
+++ b/crates/sigye/src/modes/clock.rs
@@ -385,14 +385,7 @@ impl Mode for ClockMode {
             );
         }
 
-        // Render key hints
-        let hints = self.key_hints();
-        let hint_str: String = hints
-            .iter()
-            .map(|(k, v)| format!("[{k}] {v}"))
-            .collect::<Vec<_>>()
-            .join("  ");
-        render::render_centered_text(frame, chunks[8], &hint_str, ctx.dim_color());
+        render::render_key_hints(frame, chunks[8], ctx, &self.key_hints());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {
@@ -437,5 +430,83 @@ impl Mode for ClockMode {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use ratatui::{Terminal, backend::TestBackend};
+    use sigye_config::Config;
+    use sigye_fonts::FontRegistry;
+
+    use super::*;
+
+    fn render_context(screensaver_mode: bool) -> RenderContext {
+        let config = Config::default();
+        RenderContext {
+            time_format: config.time_format,
+            color_theme: config.color_theme,
+            animation_style: config.animation_style,
+            animation_speed: config.animation_speed,
+            colon_blink: config.colon_blink,
+            show_seconds: config.show_seconds,
+            background_style: config.background_style,
+            current_font: config.font_name.clone(),
+            font_registry: FontRegistry::new(),
+            on_complete_command: config.on_complete.clone(),
+            config,
+            animation_start: Instant::now(),
+            flash_intensity: 0.0,
+            flash_start: None,
+            screensaver_mode,
+            desktop_notifications: false,
+            sunrise_sunset: None,
+        }
+    }
+
+    #[test]
+    fn render_shows_settings_hint_by_default() {
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        let mode = ClockMode::new();
+        let ctx = render_context(false);
+
+        terminal.draw(|frame| mode.render(frame, &ctx)).unwrap();
+
+        assert!(buffer_contains_text(terminal.backend(), "[s] settings"));
+    }
+
+    #[test]
+    fn render_hides_settings_hint_in_screensaver_mode() {
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        let mode = ClockMode::new();
+        let ctx = render_context(true);
+
+        terminal.draw(|frame| mode.render(frame, &ctx)).unwrap();
+
+        assert!(!buffer_contains_text(terminal.backend(), "[s] settings"));
+    }
+
+    fn buffer_contains_text(backend: &TestBackend, text: &str) -> bool {
+        let buffer = backend.buffer();
+        let area = buffer.area;
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if text_matches_at(backend, x, y, text) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn text_matches_at(backend: &TestBackend, x: u16, y: u16, text: &str) -> bool {
+        let buffer = backend.buffer();
+        text.chars().enumerate().all(|(offset, ch)| {
+            buffer
+                .cell((x + offset as u16, y))
+                .is_some_and(|cell| cell.symbol() == ch.to_string())
+        })
     }
 }

--- a/crates/sigye/src/modes/countdown.rs
+++ b/crates/sigye/src/modes/countdown.rs
@@ -290,13 +290,7 @@ impl CountdownMode {
         ]);
         frame.render_widget(Paragraph::new(cta).alignment(Alignment::Center), chunks[11]);
 
-        let hints = self.key_hints();
-        let hint_str: String = hints
-            .iter()
-            .map(|(k, v)| format!("[{k}] {v}"))
-            .collect::<Vec<_>>()
-            .join("  ");
-        render::render_centered_text(frame, chunks[13], &hint_str, dim);
+        render::render_key_hints(frame, chunks[13], ctx, &self.key_hints());
     }
 }
 
@@ -363,13 +357,7 @@ impl Mode for CountdownMode {
             render::render_centered_text(frame, chunks[6], &pager, ctx.dim_color());
         }
 
-        let hints = self.key_hints();
-        let hint_str: String = hints
-            .iter()
-            .map(|(k, v)| format!("[{k}] {v}"))
-            .collect::<Vec<_>>()
-            .join("  ");
-        render::render_centered_text(frame, chunks[7], &hint_str, ctx.dim_color());
+        render::render_key_hints(frame, chunks[7], ctx, &self.key_hints());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {
@@ -411,7 +399,47 @@ impl Mode for CountdownMode {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
+    use ratatui::{Terminal, backend::TestBackend};
+    use sigye_config::Config;
+    use sigye_fonts::FontRegistry;
+
     use super::*;
+
+    fn render_context(screensaver_mode: bool) -> RenderContext {
+        let config = Config::default();
+        RenderContext {
+            time_format: config.time_format,
+            color_theme: config.color_theme,
+            animation_style: config.animation_style,
+            animation_speed: config.animation_speed,
+            colon_blink: config.colon_blink,
+            show_seconds: config.show_seconds,
+            background_style: config.background_style,
+            current_font: config.font_name.clone(),
+            font_registry: FontRegistry::new(),
+            on_complete_command: config.on_complete.clone(),
+            config,
+            animation_start: Instant::now(),
+            flash_intensity: 0.0,
+            flash_start: None,
+            screensaver_mode,
+            desktop_notifications: false,
+            sunrise_sunset: None,
+        }
+    }
+
+    #[test]
+    fn onboarding_hides_settings_hint_in_screensaver_mode() {
+        let mut terminal = Terminal::new(TestBackend::new(100, 35)).unwrap();
+        let mode = CountdownMode::new();
+        let ctx = render_context(true);
+
+        terminal.draw(|frame| mode.render(frame, &ctx)).unwrap();
+
+        assert!(!buffer_contains_text(terminal.backend(), "[s] settings"));
+    }
 
     #[test]
     fn parses_iso_date() {
@@ -481,5 +509,27 @@ mod tests {
         let view = compute_event_view(&ev);
         assert_eq!(view.big_text, "TODAY");
         assert_eq!(view.status, "Birthday");
+    }
+
+    fn buffer_contains_text(backend: &TestBackend, text: &str) -> bool {
+        let buffer = backend.buffer();
+        let area = buffer.area;
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if text_matches_at(backend, x, y, text) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn text_matches_at(backend: &TestBackend, x: u16, y: u16, text: &str) -> bool {
+        let buffer = backend.buffer();
+        text.chars().enumerate().all(|(offset, ch)| {
+            buffer
+                .cell((x + offset as u16, y))
+                .is_some_and(|cell| cell.symbol() == ch.to_string())
+        })
     }
 }

--- a/crates/sigye/src/modes/pomodoro.rs
+++ b/crates/sigye/src/modes/pomodoro.rs
@@ -220,14 +220,7 @@ impl Mode for PomodoroMode {
         let bar_widget = Paragraph::new(bar).alignment(Alignment::Center);
         frame.render_widget(bar_widget, chunks[4]);
 
-        // Key hints
-        let hints = self.key_hints();
-        let hint_str: String = hints
-            .iter()
-            .map(|(k, v)| format!("[{k}] {v}"))
-            .collect::<Vec<_>>()
-            .join("  ");
-        render::render_centered_text(frame, chunks[6], &hint_str, ctx.dim_color());
+        render::render_key_hints(frame, chunks[6], ctx, &self.key_hints());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/stopwatch.rs
+++ b/crates/sigye/src/modes/stopwatch.rs
@@ -180,14 +180,7 @@ impl Mode for StopwatchMode {
             }
         }
 
-        // Key hints
-        let hints = self.key_hints();
-        let hint_str: String = hints
-            .iter()
-            .map(|(k, v)| format!("[{k}] {v}"))
-            .collect::<Vec<_>>()
-            .join("  ");
-        render::render_centered_text(frame, chunks[6], &hint_str, ctx.dim_color());
+        render::render_key_hints(frame, chunks[6], ctx, &self.key_hints());
     }
 
     fn handle_key(&mut self, key: KeyEvent, _ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/timer.rs
+++ b/crates/sigye/src/modes/timer.rs
@@ -177,14 +177,7 @@ impl Mode for TimerMode {
         let bar_widget = Paragraph::new(bar).alignment(Alignment::Center);
         frame.render_widget(bar_widget, chunks[3]);
 
-        // Key hints
-        let hints = self.key_hints();
-        let hint_str: String = hints
-            .iter()
-            .map(|(k, v)| format!("[{k}] {v}"))
-            .collect::<Vec<_>>()
-            .join("  ");
-        render::render_centered_text(frame, chunks[5], &hint_str, ctx.dim_color());
+        render::render_key_hints(frame, chunks[5], ctx, &self.key_hints());
     }
 
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/modes/world_clock.rs
+++ b/crates/sigye/src/modes/world_clock.rs
@@ -136,15 +136,8 @@ impl Mode for WorldClockMode {
             render::render_ascii_text(frame, entry_chunks[1], font, &time_str, &params);
         }
 
-        // Key hints (last chunk)
         let hints_area = chunks[chunks.len() - 1];
-        let hints = self.key_hints();
-        let hint_str: String = hints
-            .iter()
-            .map(|(k, v)| format!("[{k}] {v}"))
-            .collect::<Vec<_>>()
-            .join("  ");
-        render::render_centered_text(frame, hints_area, &hint_str, ctx.dim_color());
+        render::render_key_hints(frame, hints_area, ctx, &self.key_hints());
     }
 
     fn handle_key(&mut self, _key: KeyEvent, _ctx: &mut RenderContext) -> bool {

--- a/crates/sigye/src/render.rs
+++ b/crates/sigye/src/render.rs
@@ -9,6 +9,8 @@ use ratatui::{
 use sigye_core::{AnimationSpeed, AnimationStyle, ColorTheme, apply_animation, is_colon_visible};
 use sigye_fonts::Font;
 
+use crate::context::RenderContext;
+
 /// Parameters for rendering ASCII art text to the frame buffer.
 pub struct AsciiTextParams {
     pub color_theme: ColorTheme,
@@ -149,4 +151,23 @@ pub fn render_progress_bar(progress: f64, width: u16, accent: Color) -> Line<'st
         Span::styled(filled_str, Style::default().fg(accent)),
         Span::styled(empty_str, Style::default().dark_gray()),
     ])
+}
+
+/// Render mode key hints unless screensaver mode is hiding UI chrome.
+pub fn render_key_hints(
+    frame: &mut Frame,
+    area: Rect,
+    ctx: &RenderContext,
+    hints: &[(&str, &str)],
+) {
+    if ctx.screensaver_mode {
+        return;
+    }
+
+    let hint_str = hints
+        .iter()
+        .map(|(key, value)| format!("[{key}] {value}"))
+        .collect::<Vec<_>>()
+        .join("  ");
+    render_centered_text(frame, area, &hint_str, ctx.dim_color());
 }


### PR DESCRIPTION
## Summary

- Hide mode key-hint footers when `--screensaver` is active.
- Add a shared `render_key_hints` helper so all display modes honor screensaver mode consistently.
- Add render tests for Clock and Countdown screensaver behavior.

## Root Cause

`--screensaver` was stored in `RenderContext`, but mode renderers ignored it and always drew bottom key hints such as `[s] settings`.

Related to #42.

## Validation

- `mise exec -- cargo test --workspace`
- `mise exec -- cargo clippy --workspace --all-targets -- -D warnings`
